### PR TITLE
FIX Different log type in libraries and general logs

### DIFF
--- a/lib/iotagent-mqtt.js
+++ b/lib/iotagent-mqtt.js
@@ -443,6 +443,7 @@ function start(newConfig, callback) {
         connectTimeout: 60 * 60 * 1000
     };
 
+    logger.format = logger.formatters.pipe;
     config = newConfig;
 
     if (config.mqtt.username && config.mqtt.password) {


### PR DESCRIPTION
Fix the different log type (JSON or Pipe) for the library and the IOTA log.